### PR TITLE
Rename Fragments to make their roles more obvious

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -6,6 +6,7 @@
         <entry key="app/src/main/res/layout/activity_main.xml" value="0.25" />
         <entry key="app/src/main/res/layout/content_main.xml" value="0.1921875" />
         <entry key="app/src/main/res/layout/fragment_first.xml" value="0.25" />
+        <entry key="app/src/main/res/layout/fragment_new_habit.xml" value="0.25" />
         <entry key="app/src/main/res/layout/fragment_second.xml" value="0.33" />
         <entry key="app/src/main/res/layout/habit_item.xml" value="0.5" />
       </map>

--- a/app/src/main/java/com/github/cmput301f21t44/hellohabits/view/MainActivity.java
+++ b/app/src/main/java/com/github/cmput301f21t44/hellohabits/view/MainActivity.java
@@ -12,7 +12,6 @@ import androidx.navigation.ui.NavigationUI;
 
 import com.github.cmput301f21t44.hellohabits.R;
 import com.github.cmput301f21t44.hellohabits.databinding.ActivityMainBinding;
-import com.github.cmput301f21t44.hellohabits.viewmodel.HabitViewModel;
 import com.google.android.material.snackbar.Snackbar;
 
 public class MainActivity extends AppCompatActivity {

--- a/app/src/main/java/com/github/cmput301f21t44/hellohabits/view/NewHabitFragment.java
+++ b/app/src/main/java/com/github/cmput301f21t44/hellohabits/view/NewHabitFragment.java
@@ -12,7 +12,7 @@ import androidx.lifecycle.ViewModelProvider;
 import androidx.navigation.fragment.NavHostFragment;
 
 import com.github.cmput301f21t44.hellohabits.R;
-import com.github.cmput301f21t44.hellohabits.databinding.FragmentSecondBinding;
+import com.github.cmput301f21t44.hellohabits.databinding.FragmentNewHabitBinding;
 import com.github.cmput301f21t44.hellohabits.viewmodel.HabitViewModel;
 
 import java.time.Instant;
@@ -20,9 +20,9 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 
-public class SecondFragment extends Fragment {
+public class NewHabitFragment extends Fragment {
 
-    private FragmentSecondBinding binding;
+    private FragmentNewHabitBinding binding;
     private HabitViewModel mHabitViewModel;
     private Instant mInstant;
 
@@ -32,7 +32,7 @@ public class SecondFragment extends Fragment {
             Bundle savedInstanceState
     ) {
 
-        binding = FragmentSecondBinding.inflate(inflater, container, false);
+        binding = FragmentNewHabitBinding.inflate(inflater, container, false);
         return binding.getRoot();
 
     }
@@ -54,8 +54,8 @@ public class SecondFragment extends Fragment {
                     binding.editTextTitle.getText().toString(),
                     binding.editTextReason.getText().toString(),
                     mInstant);
-            NavHostFragment.findNavController(SecondFragment.this)
-                    .navigate(R.id.action_SecondFragment_to_FirstFragment);
+            NavHostFragment.findNavController(NewHabitFragment.this)
+                    .navigate(R.id.action_NewHabitFragment_to_TodaysHabitsFragment);
         });
 
         binding.textDateStarted.setOnClickListener(v -> {
@@ -69,9 +69,9 @@ public class SecondFragment extends Fragment {
             newFragment.show(requireActivity().getSupportFragmentManager(), "datePicker");
         });
 
-        binding.buttonSecond.setOnClickListener(view1 -> NavHostFragment
-                .findNavController(SecondFragment.this)
-                .navigate(R.id.action_SecondFragment_to_FirstFragment));
+        binding.buttonBack.setOnClickListener(view1 -> NavHostFragment
+                .findNavController(NewHabitFragment.this)
+                .navigate(R.id.action_NewHabitFragment_to_TodaysHabitsFragment));
     }
 
     @Override

--- a/app/src/main/java/com/github/cmput301f21t44/hellohabits/view/TodaysHabitsFragment.java
+++ b/app/src/main/java/com/github/cmput301f21t44/hellohabits/view/TodaysHabitsFragment.java
@@ -6,33 +6,28 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.navigation.fragment.NavHostFragment;
 import androidx.recyclerview.widget.LinearLayoutManager;
 
 import com.github.cmput301f21t44.hellohabits.R;
-import com.github.cmput301f21t44.hellohabits.databinding.FragmentFirstBinding;
-import com.github.cmput301f21t44.hellohabits.db.HabitEntity;
+import com.github.cmput301f21t44.hellohabits.databinding.FragmentTodaysHabitsBinding;
 import com.github.cmput301f21t44.hellohabits.model.Habit;
 import com.github.cmput301f21t44.hellohabits.viewmodel.HabitViewModel;
 
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
-import java.util.ListIterator;
 
-public class FirstFragment extends Fragment {
+public class TodaysHabitsFragment extends Fragment {
 
-    private FragmentFirstBinding binding;
+    private FragmentTodaysHabitsBinding binding;
     private HabitViewModel mHabitViewModel;
     private HabitAdapter adapter;
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        binding = FragmentFirstBinding.inflate(inflater, container, false);
+        binding = FragmentTodaysHabitsBinding.inflate(inflater, container, false);
         return binding.getRoot();
     }
 
@@ -44,9 +39,9 @@ public class FirstFragment extends Fragment {
         binding.habitRecyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
 
 
-        binding.buttonFirst.setOnClickListener(view1 ->
-                NavHostFragment.findNavController(FirstFragment.this)
-                        .navigate(R.id.action_FirstFragment_to_SecondFragment));
+        binding.buttonNewHabit.setOnClickListener(view1 ->
+                NavHostFragment.findNavController(TodaysHabitsFragment.this)
+                        .navigate(R.id.action_TodaysHabitsFragment_to_NewHabitFragment));
     }
 
     @Override

--- a/app/src/main/res/layout/fragment_new_habit.xml
+++ b/app/src/main/res/layout/fragment_new_habit.xml
@@ -4,22 +4,13 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".view.SecondFragment">
-
-    <TextView
-        android:id="@+id/textview_second"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:layout_constraintBottom_toTopOf="@id/button_second"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+    tools:context=".view.NewHabitFragment">
 
     <Button
-        android:id="@+id/button_second"
+        android:id="@+id/button_back"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/previous"
+        android:text="@string/back"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.5"
@@ -42,7 +33,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="Add Habit"
-        app:layout_constraintBottom_toTopOf="@+id/button_second"
+        app:layout_constraintBottom_toTopOf="@+id/button_back"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/fragment_todays_habits.xml
+++ b/app/src/main/res/layout/fragment_todays_habits.xml
@@ -4,21 +4,24 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".view.FirstFragment">
+    tools:context=".view.TodaysHabitsFragment">
 
     <Button
-        android:id="@+id/button_first"
+        android:id="@+id/button_new_habit"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/next"
+        android:text="@string/new_habit"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/habit_recycler_view" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/habit_recycler_view"
         android:layout_width="409dp"
         android:layout_height="681dp"
-        tools:layout_editor_absoluteX="1dp"
-        tools:layout_editor_absoluteY="1dp" />
+        app:layout_constraintBottom_toTopOf="@+id/button_new_habit"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -3,26 +3,26 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/nav_graph"
-    app:startDestination="@id/FirstFragment">
+    app:startDestination="@id/TodaysHabitsFragment">
 
     <fragment
-        android:id="@+id/FirstFragment"
-        android:name="com.github.cmput301f21t44.hellohabits.view.FirstFragment"
-        android:label="@string/first_fragment_label"
-        tools:layout="@layout/fragment_first">
+        android:id="@+id/TodaysHabitsFragment"
+        android:name="com.github.cmput301f21t44.hellohabits.view.TodaysHabitsFragment"
+        android:label="@string/todays_habits_fragment_label"
+        tools:layout="@layout/fragment_todays_habits">
 
         <action
-            android:id="@+id/action_FirstFragment_to_SecondFragment"
-            app:destination="@id/SecondFragment" />
+            android:id="@+id/action_TodaysHabitsFragment_to_NewHabitFragment"
+            app:destination="@id/NewHabitFragment" />
     </fragment>
     <fragment
-        android:id="@+id/SecondFragment"
-        android:name="com.github.cmput301f21t44.hellohabits.view.SecondFragment"
-        android:label="@string/second_fragment_label"
-        tools:layout="@layout/fragment_second">
+        android:id="@+id/NewHabitFragment"
+        android:name="com.github.cmput301f21t44.hellohabits.view.NewHabitFragment"
+        android:label="@string/new_habit_fragment_label"
+        tools:layout="@layout/fragment_new_habit">
 
         <action
-            android:id="@+id/action_SecondFragment_to_FirstFragment"
-            app:destination="@id/FirstFragment" />
+            android:id="@+id/action_NewHabitFragment_to_TodaysHabitsFragment"
+            app:destination="@id/TodaysHabitsFragment" />
     </fragment>
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,13 +2,11 @@
     <string name="app_name">HelloHabits</string>
     <string name="action_settings">Settings</string>
     <!-- Strings used for fragments for navigation -->
-    <string name="first_fragment_label">First Fragment</string>
-    <string name="second_fragment_label">Second Fragment</string>
-    <string name="next">Next</string>
-    <string name="previous">Previous</string>
+    <string name="todays_habits_fragment_label">Today\'s Habits Fragment</string>
+    <string name="new_habit_fragment_label">New Habit Fragment</string>
+    <string name="new_habit">New Habit</string>
+    <string name="back">Back</string>
 
-    <string name="hello_first_fragment">Hello first fragment</string>
-    <string name="hello_second_fragment">Hello second fragment. Arg: %1$s</string>
     <string name="title">Title</string>
     <string name="reason">Reason</string>
 </resources>


### PR DESCRIPTION
Renamed `FirstFragment` to `TodaysHabitsFragment` and `SecondFragment`
to `NewHabitFragment`. Also changed the navigation and the layout
fragment names accordingly.
