### PR TITLE
Remove dependency from Room repositories

### DIFF
--- a/app/src/main/java/com/github/cmput301f21t44/hellohabits/db/habit/HabitEntityRepository.java
+++ b/app/src/main/java/com/github/cmput301f21t44/hellohabits/db/habit/HabitEntityRepository.java
@@ -3,43 +3,47 @@ package com.github.cmput301f21t44.hellohabits.db.habit;
 import android.app.Application;
 
 import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MediatorLiveData;
 
 import com.github.cmput301f21t44.hellohabits.db.AppDatabase;
+import com.github.cmput301f21t44.hellohabits.model.Habit;
 import com.github.cmput301f21t44.hellohabits.model.HabitRepository;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 
-public class HabitEntityRepository implements HabitRepository<HabitWithEvents> {
+public class HabitEntityRepository implements HabitRepository {
     private final HabitDao mHabitDao;
-    private final LiveData<List<HabitWithEvents>> mAllHabits;
+    private final MediatorLiveData<List<Habit>> mAllHabits;
 
     public HabitEntityRepository(Application application) {
         AppDatabase db = AppDatabase.getDatabase(application);
         mHabitDao = db.habitDao();
-        mAllHabits = mHabitDao.getAllHabits();
+        mAllHabits = new MediatorLiveData<>();
+        mAllHabits.addSource(mHabitDao.getAllHabits(), habitList ->
+                mAllHabits.setValue(new ArrayList<>(habitList)));
     }
 
-    public LiveData<List<HabitWithEvents>> getAllHabits() {
+    public LiveData<List<Habit>> getAllHabits() {
         return mAllHabits;
     }
 
-
     @Override
     public void insert(String title, String reason, Instant dateStarted, boolean[] daysOfWeek) {
-        HabitEntity habit = new HabitEntity(title, reason, dateStarted, daysOfWeek);
-        AppDatabase.databaseWriteExecutor.execute(() -> mHabitDao.insert(habit));
+        HabitEntity newHabit = new HabitEntity(title, reason, dateStarted, daysOfWeek);
+        AppDatabase.databaseWriteExecutor.execute(() -> mHabitDao.insert(newHabit));
     }
 
     @Override
-    public void delete(HabitWithEvents habit) {
-        AppDatabase.databaseWriteExecutor.execute(() -> mHabitDao.delete(habit.getHabitEntity()));
+    public void delete(Habit habit) {
+        AppDatabase.databaseWriteExecutor.execute(() -> mHabitDao.delete(HabitEntity.from(habit)));
     }
 
 
     @Override
-    public HabitWithEvents update(String id, String title, String reason, Instant dateStarted,
-                                  boolean[] daysOfWeek) {
+    public Habit update(String id, String title, String reason, Instant dateStarted,
+                        boolean[] daysOfWeek) {
         HabitEntity updatedEntity = new HabitEntity(id, title, reason, dateStarted, daysOfWeek);
         AppDatabase.databaseWriteExecutor.execute(() -> mHabitDao.update(updatedEntity));
 

--- a/app/src/main/java/com/github/cmput301f21t44/hellohabits/db/habitevent/HabitEventEntityRepository.java
+++ b/app/src/main/java/com/github/cmput301f21t44/hellohabits/db/habitevent/HabitEventEntityRepository.java
@@ -3,15 +3,18 @@ package com.github.cmput301f21t44.hellohabits.db.habitevent;
 import android.app.Application;
 
 import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MediatorLiveData;
 
 import com.github.cmput301f21t44.hellohabits.db.AppDatabase;
+import com.github.cmput301f21t44.hellohabits.model.HabitEvent;
 import com.github.cmput301f21t44.hellohabits.model.HabitEventRepository;
 import com.github.cmput301f21t44.hellohabits.model.Location;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 
-public class HabitEventEntityRepository implements HabitEventRepository<HabitEventEntity> {
+public class HabitEventEntityRepository implements HabitEventRepository {
     private final HabitEventDao mHabitEventDao;
 
     public HabitEventEntityRepository(Application application) {
@@ -19,24 +22,29 @@ public class HabitEventEntityRepository implements HabitEventRepository<HabitEve
         mHabitEventDao = db.habitEventDao();
     }
 
-    public LiveData<List<HabitEventEntity>> getEventsByHabitId(String habitId) {
-        return mHabitEventDao.getEventsByHabitId(habitId);
+    public LiveData<List<HabitEvent>> getEventsByHabitId(String habitId) {
+        MediatorLiveData<List<HabitEvent>> habitEventList = new MediatorLiveData<>();
+        habitEventList.addSource(mHabitEventDao.getEventsByHabitId(habitId), habitEventEntities ->
+                habitEventList.setValue(new ArrayList<>(habitEventEntities)));
+        return habitEventList;
+
     }
 
     @Override
     public void insert(String habitId, String comment) {
-        HabitEventEntity habitEvent = new HabitEventEntity(habitId, Instant.now(), comment, null,
+        HabitEventEntity newHabitEvent = new HabitEventEntity(habitId, Instant.now(), comment, null,
                 null);
-        AppDatabase.databaseWriteExecutor.execute(() -> mHabitEventDao.insert(habitEvent));
+        AppDatabase.databaseWriteExecutor.execute(() -> mHabitEventDao.insert(newHabitEvent));
     }
 
     @Override
-    public void delete(HabitEventEntity habitEvent) {
-        AppDatabase.databaseWriteExecutor.execute(() -> mHabitEventDao.delete(habitEvent));
+    public void delete(HabitEvent habitEvent) {
+        AppDatabase.databaseWriteExecutor.execute(() -> mHabitEventDao
+                .delete(HabitEventEntity.from(habitEvent)));
     }
 
     @Override
-    public HabitEventEntity update(String id, String habitId, Instant date, String comment, String photoPath, Location location) {
+    public HabitEvent update(String id, String habitId, Instant date, String comment, String photoPath, Location location) {
         HabitEventEntity updatedEvent = new HabitEventEntity(id, habitId, date, comment, photoPath, location);
         AppDatabase.databaseWriteExecutor.execute(() -> mHabitEventDao.update(updatedEvent));
         return updatedEvent;

--- a/app/src/main/java/com/github/cmput301f21t44/hellohabits/model/HabitEventRepository.java
+++ b/app/src/main/java/com/github/cmput301f21t44/hellohabits/model/HabitEventRepository.java
@@ -1,11 +1,16 @@
 package com.github.cmput301f21t44.hellohabits.model;
 
-import java.time.Instant;
+import androidx.lifecycle.LiveData;
 
-public interface HabitEventRepository<T extends HabitEvent> {
+import java.time.Instant;
+import java.util.List;
+
+public interface HabitEventRepository {
     void insert(String habitId, String comment);
 
-    void delete(T habitEvent);
+    void delete(HabitEvent habitEvent);
 
-    T update(String id, String habitId, Instant date, String comment, String photoPath, Location location);
+    LiveData<List<HabitEvent>> getEventsByHabitId(String habitId);
+
+    HabitEvent update(String id, String habitId, Instant date, String comment, String photoPath, Location location);
 }

--- a/app/src/main/java/com/github/cmput301f21t44/hellohabits/model/HabitRepository.java
+++ b/app/src/main/java/com/github/cmput301f21t44/hellohabits/model/HabitRepository.java
@@ -5,12 +5,12 @@ import androidx.lifecycle.LiveData;
 import java.time.Instant;
 import java.util.List;
 
-public interface HabitRepository<T extends Habit> {
-    LiveData<List<T>> getAllHabits();
+public interface HabitRepository {
+    LiveData<List<Habit>> getAllHabits();
 
     void insert(String title, String reason, Instant dateStarted, boolean[] daysOfWeek);
 
-    void delete(T habit);
+    void delete(Habit habit);
 
-    T update(String id, String title, String reason, Instant dateStarted, boolean[] daysOfWeek);
+    Habit update(String id, String title, String reason, Instant dateStarted, boolean[] daysOfWeek);
 }

--- a/app/src/main/java/com/github/cmput301f21t44/hellohabits/viewmodel/HabitEventViewModel.java
+++ b/app/src/main/java/com/github/cmput301f21t44/hellohabits/viewmodel/HabitEventViewModel.java
@@ -4,20 +4,18 @@ import android.app.Application;
 
 import androidx.lifecycle.AndroidViewModel;
 import androidx.lifecycle.LiveData;
-import androidx.lifecycle.MediatorLiveData;
 import androidx.lifecycle.MutableLiveData;
 
-import com.github.cmput301f21t44.hellohabits.db.habitevent.HabitEventEntity;
 import com.github.cmput301f21t44.hellohabits.db.habitevent.HabitEventEntityRepository;
 import com.github.cmput301f21t44.hellohabits.model.HabitEvent;
+import com.github.cmput301f21t44.hellohabits.model.HabitEventRepository;
 import com.github.cmput301f21t44.hellohabits.model.Location;
 
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.List;
 
 public class HabitEventViewModel extends AndroidViewModel {
-    private final HabitEventEntityRepository mRepository;
+    private final HabitEventRepository mRepository;
     private final MutableLiveData<HabitEvent> selected = new MutableLiveData<>();
 
     public HabitEventViewModel(Application application) {
@@ -26,13 +24,7 @@ public class HabitEventViewModel extends AndroidViewModel {
     }
 
     public LiveData<List<HabitEvent>> getHabitEventsById(String habitId) {
-        MediatorLiveData<List<HabitEvent>> habitEvents = new MediatorLiveData<>();
-        habitEvents.addSource(mRepository.getEventsByHabitId(habitId), v -> {
-            List<HabitEvent> list = new ArrayList<>(v);
-            habitEvents.setValue(list);
-        });
-
-        return habitEvents;
+        return mRepository.getEventsByHabitId(habitId);
     }
 
     public void insert(String habitId, String comment) {
@@ -44,7 +36,7 @@ public class HabitEventViewModel extends AndroidViewModel {
     }
 
     public void delete(HabitEvent habitEvent) {
-        mRepository.delete(HabitEventEntity.from(habitEvent));
+        mRepository.delete(habitEvent);
     }
 
     public void select(HabitEvent habit) {

--- a/app/src/main/java/com/github/cmput301f21t44/hellohabits/viewmodel/HabitViewModel.java
+++ b/app/src/main/java/com/github/cmput301f21t44/hellohabits/viewmodel/HabitViewModel.java
@@ -6,17 +6,16 @@ import androidx.lifecycle.AndroidViewModel;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 
-import com.github.cmput301f21t44.hellohabits.db.habit.HabitEntity;
 import com.github.cmput301f21t44.hellohabits.db.habit.HabitEntityRepository;
-import com.github.cmput301f21t44.hellohabits.db.habit.HabitWithEvents;
 import com.github.cmput301f21t44.hellohabits.model.Habit;
+import com.github.cmput301f21t44.hellohabits.model.HabitRepository;
 
 import java.time.Instant;
 import java.util.List;
 
 public class HabitViewModel extends AndroidViewModel {
-    private final HabitEntityRepository mRepository;
-    private final LiveData<List<HabitWithEvents>> mAllHabits;
+    private final HabitRepository mRepository;
+    private final LiveData<List<Habit>> mAllHabits;
 
     private final MutableLiveData<Habit> selected = new MutableLiveData<>();
 
@@ -34,7 +33,7 @@ public class HabitViewModel extends AndroidViewModel {
         return selected;
     }
 
-    public LiveData<List<HabitWithEvents>> getAllHabits() {
+    public LiveData<List<Habit>> getAllHabits() {
         return mAllHabits;
     }
 
@@ -47,10 +46,6 @@ public class HabitViewModel extends AndroidViewModel {
     }
 
     public void delete(Habit habit) {
-        /*
-          This ViewModel depends on HabitEntity right now, but shouldn't.
-          We'll make sure that the repository will be implementation-agnostic in the future.
-         */
-        mRepository.delete(new HabitWithEvents(HabitEntity.from(habit)));
+        mRepository.delete(habit);
     }
 }


### PR DESCRIPTION
Used Mediator LiveData to convert `List<HabitWithEvents>` to `List<Habit>`
and `List<HabitEventEntity>` to `List<HabitEvent>`. Now the Repository
interfaces do not take a generic type and the ViewModels do not depend
on a specific implementation of Habit and HabitEvent.
