### PR TITLE
Remove Application dependency from ViewModels

### DIFF
--- a/app/src/main/java/com/github/cmput301f21t44/hellohabits/view/MainActivity.java
+++ b/app/src/main/java/com/github/cmput301f21t44/hellohabits/view/MainActivity.java
@@ -15,7 +15,6 @@ import com.github.cmput301f21t44.hellohabits.databinding.ActivityMainBinding;
 import com.google.android.material.snackbar.Snackbar;
 
 public class MainActivity extends AppCompatActivity {
-
     private AppBarConfiguration appBarConfiguration;
     private ActivityMainBinding binding;
 

--- a/app/src/main/java/com/github/cmput301f21t44/hellohabits/view/habit/AllHabitsFragment.java
+++ b/app/src/main/java/com/github/cmput301f21t44/hellohabits/view/habit/AllHabitsFragment.java
@@ -16,6 +16,7 @@ import com.github.cmput301f21t44.hellohabits.R;
 import com.github.cmput301f21t44.hellohabits.databinding.FragmentAllHabitsBinding;
 import com.github.cmput301f21t44.hellohabits.model.Habit;
 import com.github.cmput301f21t44.hellohabits.viewmodel.HabitViewModel;
+import com.github.cmput301f21t44.hellohabits.viewmodel.ViewModelFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,7 +40,8 @@ public class AllHabitsFragment extends Fragment {
         super.onViewCreated(view, savedInstanceState);
         mNavController = NavHostFragment.findNavController(this);
         // attach the provider to activity instead of fragment so the fragments can share data
-        mHabitViewModel = new ViewModelProvider(requireActivity()).get(HabitViewModel.class);
+        ViewModelProvider provider = ViewModelFactory.getProvider(requireActivity());
+        mHabitViewModel = provider.get(HabitViewModel.class);
         adapter = HabitAdapter.newInstance((habit) -> {
             mHabitViewModel.select(habit);
             mNavController.navigate(R.id.action_allHabitsFragment_to_viewHabitFragment);

--- a/app/src/main/java/com/github/cmput301f21t44/hellohabits/view/habit/CreateEditHabitFragment.java
+++ b/app/src/main/java/com/github/cmput301f21t44/hellohabits/view/habit/CreateEditHabitFragment.java
@@ -17,6 +17,7 @@ import com.github.cmput301f21t44.hellohabits.databinding.FragmentCreateEditHabit
 import com.github.cmput301f21t44.hellohabits.model.DaysOfWeek;
 import com.github.cmput301f21t44.hellohabits.model.Habit;
 import com.github.cmput301f21t44.hellohabits.viewmodel.HabitViewModel;
+import com.github.cmput301f21t44.hellohabits.viewmodel.ViewModelFactory;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -90,7 +91,8 @@ public class CreateEditHabitFragment extends Fragment {
 
     public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-        mHabitViewModel = new ViewModelProvider(requireActivity()).get(HabitViewModel.class);
+        ViewModelProvider provider = ViewModelFactory.getProvider(requireActivity());
+        mHabitViewModel = provider.get(HabitViewModel.class);
         mNavController = NavHostFragment.findNavController(this);
 
         binding.buttonAddHabit.setOnClickListener(v -> submitHabit());

--- a/app/src/main/java/com/github/cmput301f21t44/hellohabits/view/habit/TodaysHabitsFragment.java
+++ b/app/src/main/java/com/github/cmput301f21t44/hellohabits/view/habit/TodaysHabitsFragment.java
@@ -16,6 +16,7 @@ import com.github.cmput301f21t44.hellohabits.R;
 import com.github.cmput301f21t44.hellohabits.databinding.FragmentTodaysHabitsBinding;
 import com.github.cmput301f21t44.hellohabits.model.Habit;
 import com.github.cmput301f21t44.hellohabits.viewmodel.HabitViewModel;
+import com.github.cmput301f21t44.hellohabits.viewmodel.ViewModelFactory;
 
 import java.time.Instant;
 import java.time.ZoneId;
@@ -41,8 +42,8 @@ public class TodaysHabitsFragment extends Fragment {
     public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         mNavController = NavHostFragment.findNavController(this);
-        // attach the provider to activity instead of fragment so the fragments can share data
-        mHabitViewModel = new ViewModelProvider(requireActivity()).get(HabitViewModel.class);
+        ViewModelProvider provider = ViewModelFactory.getProvider(requireActivity());
+        mHabitViewModel = provider.get(HabitViewModel.class);
         adapter = HabitAdapter.newInstance((habit) -> {
             mHabitViewModel.select(habit);
             mNavController.navigate(R.id.action_todaysHabitsFragment_to_viewHabitFragment);

--- a/app/src/main/java/com/github/cmput301f21t44/hellohabits/view/habit/ViewHabitFragment.java
+++ b/app/src/main/java/com/github/cmput301f21t44/hellohabits/view/habit/ViewHabitFragment.java
@@ -17,6 +17,7 @@ import com.github.cmput301f21t44.hellohabits.databinding.FragmentViewHabitBindin
 import com.github.cmput301f21t44.hellohabits.model.DaysOfWeek;
 import com.github.cmput301f21t44.hellohabits.viewmodel.HabitEventViewModel;
 import com.github.cmput301f21t44.hellohabits.viewmodel.HabitViewModel;
+import com.github.cmput301f21t44.hellohabits.viewmodel.ViewModelFactory;
 
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
@@ -38,9 +39,9 @@ public class ViewHabitFragment extends Fragment {
     public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         // attach the provider to activity instead of fragment so the fragments can share data
-        mHabitViewModel = new ViewModelProvider(requireActivity()).get(HabitViewModel.class);
-        mHabitEventViewModel = new ViewModelProvider(requireActivity())
-                .get(HabitEventViewModel.class);
+        ViewModelProvider provider = ViewModelFactory.getProvider(requireActivity());
+        mHabitViewModel = provider.get(HabitViewModel.class);
+        mHabitEventViewModel = provider.get(HabitEventViewModel.class);
 
         mNavController = NavHostFragment.findNavController(this);
 

--- a/app/src/main/java/com/github/cmput301f21t44/hellohabits/view/habitevent/CreateEditHabitEventFragment.java
+++ b/app/src/main/java/com/github/cmput301f21t44/hellohabits/view/habitevent/CreateEditHabitEventFragment.java
@@ -18,6 +18,7 @@ import com.github.cmput301f21t44.hellohabits.model.HabitEvent;
 import com.github.cmput301f21t44.hellohabits.view.habit.CreateEditHabitFragment;
 import com.github.cmput301f21t44.hellohabits.viewmodel.HabitEventViewModel;
 import com.github.cmput301f21t44.hellohabits.viewmodel.HabitViewModel;
+import com.github.cmput301f21t44.hellohabits.viewmodel.ViewModelFactory;
 
 import java.util.Objects;
 
@@ -64,9 +65,9 @@ public class CreateEditHabitEventFragment extends Fragment {
 
     public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-        mHabitViewModel = new ViewModelProvider(requireActivity()).get(HabitViewModel.class);
-        mHabitEventViewModel = new ViewModelProvider(requireActivity())
-                .get(HabitEventViewModel.class);
+        ViewModelProvider provider = ViewModelFactory.getProvider(requireActivity());
+        mHabitViewModel = provider.get(HabitViewModel.class);
+        mHabitEventViewModel = provider.get(HabitEventViewModel.class);
         mNavController = NavHostFragment.findNavController(this);
 
         binding.buttonAddHabitEvent.setOnClickListener(v -> submitHabitEvent());

--- a/app/src/main/java/com/github/cmput301f21t44/hellohabits/view/habitevent/HabitEventListFragment.java
+++ b/app/src/main/java/com/github/cmput301f21t44/hellohabits/view/habitevent/HabitEventListFragment.java
@@ -16,6 +16,7 @@ import com.github.cmput301f21t44.hellohabits.R;
 import com.github.cmput301f21t44.hellohabits.databinding.FragmentHabitEventListBinding;
 import com.github.cmput301f21t44.hellohabits.viewmodel.HabitEventViewModel;
 import com.github.cmput301f21t44.hellohabits.viewmodel.HabitViewModel;
+import com.github.cmput301f21t44.hellohabits.viewmodel.ViewModelFactory;
 
 import java.util.Objects;
 
@@ -53,9 +54,9 @@ public class HabitEventListFragment extends Fragment {
     public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         mNavController = NavHostFragment.findNavController(this);
-        mHabitViewModel = new ViewModelProvider(requireActivity()).get(HabitViewModel.class);
-        mHabitEventViewModel = new ViewModelProvider(requireActivity())
-                .get(HabitEventViewModel.class);
+        ViewModelProvider provider = ViewModelFactory.getProvider(requireActivity());
+        mHabitViewModel = provider.get(HabitViewModel.class);
+        mHabitEventViewModel = provider.get(HabitEventViewModel.class);
         adapter = HabitEventAdapter.newInstance(habitEvent -> {
             mHabitEventViewModel.select(habitEvent);
             mNavController.navigate(R.id.action_habitEventListFragment_to_createEditHabitEventFragment);

--- a/app/src/main/java/com/github/cmput301f21t44/hellohabits/viewmodel/HabitEventViewModel.java
+++ b/app/src/main/java/com/github/cmput301f21t44/hellohabits/viewmodel/HabitEventViewModel.java
@@ -1,12 +1,9 @@
 package com.github.cmput301f21t44.hellohabits.viewmodel;
 
-import android.app.Application;
-
-import androidx.lifecycle.AndroidViewModel;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.ViewModel;
 
-import com.github.cmput301f21t44.hellohabits.db.habitevent.HabitEventEntityRepository;
 import com.github.cmput301f21t44.hellohabits.model.HabitEvent;
 import com.github.cmput301f21t44.hellohabits.model.HabitEventRepository;
 import com.github.cmput301f21t44.hellohabits.model.Location;
@@ -14,13 +11,12 @@ import com.github.cmput301f21t44.hellohabits.model.Location;
 import java.time.Instant;
 import java.util.List;
 
-public class HabitEventViewModel extends AndroidViewModel {
+public class HabitEventViewModel extends ViewModel {
     private final HabitEventRepository mRepository;
     private final MutableLiveData<HabitEvent> selected = new MutableLiveData<>();
 
-    public HabitEventViewModel(Application application) {
-        super(application);
-        mRepository = new HabitEventEntityRepository(application);
+    public HabitEventViewModel(HabitEventRepository habitEventRepository) {
+        mRepository = habitEventRepository;
     }
 
     public LiveData<List<HabitEvent>> getHabitEventsById(String habitId) {

--- a/app/src/main/java/com/github/cmput301f21t44/hellohabits/viewmodel/HabitViewModel.java
+++ b/app/src/main/java/com/github/cmput301f21t44/hellohabits/viewmodel/HabitViewModel.java
@@ -1,27 +1,23 @@
 package com.github.cmput301f21t44.hellohabits.viewmodel;
 
-import android.app.Application;
-
-import androidx.lifecycle.AndroidViewModel;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.ViewModel;
 
-import com.github.cmput301f21t44.hellohabits.db.habit.HabitEntityRepository;
 import com.github.cmput301f21t44.hellohabits.model.Habit;
 import com.github.cmput301f21t44.hellohabits.model.HabitRepository;
 
 import java.time.Instant;
 import java.util.List;
 
-public class HabitViewModel extends AndroidViewModel {
+public class HabitViewModel extends ViewModel {
     private final HabitRepository mRepository;
     private final LiveData<List<Habit>> mAllHabits;
 
     private final MutableLiveData<Habit> selected = new MutableLiveData<>();
 
-    public HabitViewModel(Application application) {
-        super(application);
-        mRepository = new HabitEntityRepository(application);
+    public HabitViewModel(HabitRepository habitRepository) {
+        mRepository = habitRepository;
         mAllHabits = mRepository.getAllHabits();
     }
 

--- a/app/src/main/java/com/github/cmput301f21t44/hellohabits/viewmodel/ViewModelFactory.java
+++ b/app/src/main/java/com/github/cmput301f21t44/hellohabits/viewmodel/ViewModelFactory.java
@@ -1,0 +1,52 @@
+package com.github.cmput301f21t44.hellohabits.viewmodel;
+
+import android.app.Application;
+
+import androidx.annotation.NonNull;
+import androidx.fragment.app.FragmentActivity;
+import androidx.lifecycle.ViewModel;
+import androidx.lifecycle.ViewModelProvider;
+
+import com.github.cmput301f21t44.hellohabits.db.habit.HabitEntityRepository;
+import com.github.cmput301f21t44.hellohabits.db.habitevent.HabitEventEntityRepository;
+import com.github.cmput301f21t44.hellohabits.model.HabitEventRepository;
+import com.github.cmput301f21t44.hellohabits.model.HabitRepository;
+
+public class ViewModelFactory extends ViewModelProvider.NewInstanceFactory {
+    private static volatile ViewModelFactory INSTANCE;
+
+    private final HabitRepository mHabitRepository;
+    private final HabitEventRepository mHabitEventRepository;
+
+    private ViewModelFactory(Application application) {
+        mHabitRepository = new HabitEntityRepository(application);
+        mHabitEventRepository = new HabitEventEntityRepository(application);
+    }
+
+    public static ViewModelProvider getProvider(FragmentActivity activity) {
+        ViewModelFactory factory = ViewModelFactory.getInstance(activity.getApplication());
+        return new ViewModelProvider(activity, factory);
+    }
+
+    public static ViewModelFactory getInstance(Application application) {
+        synchronized (ViewModelFactory.class) {
+            if (INSTANCE == null) {
+                INSTANCE = new ViewModelFactory(application);
+            }
+        }
+        return INSTANCE;
+    }
+
+    @NonNull
+    @Override
+    public <T extends ViewModel> T create(Class<T> modelClass) {
+        if (modelClass.isAssignableFrom(HabitViewModel.class)) {
+            //noinspection unchecked
+            return (T) new HabitViewModel(mHabitRepository);
+        } else if (modelClass.isAssignableFrom(HabitEventViewModel.class)) {
+            //noinspection unchecked
+            return (T) new HabitEventViewModel(mHabitEventRepository);
+        }
+        throw new IllegalArgumentException("Unknown ViewModel class: " + modelClass.getName());
+    }
+}


### PR DESCRIPTION
Created a ViewModelFactory that takes in an Application and creates the
Entity Repositories from that context.
With this the ViewModels won't have to depend on the Application anymore
but the Repository that it uses. This should make testing a bit easier.