### PR TITLE
Testing: Provide example of ViewModel testing

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,6 +50,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-auth'
 
     testImplementation 'junit:junit:4.13.2'
+    testImplementation "androidx.arch.core:core-testing:2.1.0"
     testImplementation 'org.mockito:mockito-core:2.19.0'
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'

--- a/app/src/androidTest/java/com/github/cmput301f21t44/hellohabits/HabitEventTest.java
+++ b/app/src/androidTest/java/com/github/cmput301f21t44/hellohabits/HabitEventTest.java
@@ -77,7 +77,7 @@ public class HabitEventTest {
 
 
     @Test
-    public void A_addEventTest() {
+    public void A_test_addEvent() {
         onView(withId(R.id.view_all_habits)).perform(click());
         onView(withText(HabitTest.HABIT_TITLE)).perform(click());
         onView(withId(R.id.button_new_habit_event)).perform(click());
@@ -86,14 +86,14 @@ public class HabitEventTest {
     }
 
     @Test
-    public void B_viewEventTest() {
+    public void B_test_viewEvent() {
         onView(withId(R.id.view_all_habits)).perform(click());
         onView(withText(HabitTest.HABIT_TITLE)).perform(click());
         onView(withText(EVENT_COMMENT)).check(matches(isDisplayed()));
     }
 
     @Test
-    public void C_editEventTest() {
+    public void C_test_editEvent() {
         onView(withId(R.id.view_all_habits)).perform(click());
         onView(withText(HabitTest.HABIT_TITLE)).perform(click());
         onView(withId(R.id.button_edit)).perform(click());
@@ -104,7 +104,7 @@ public class HabitEventTest {
     }
 
     @Test
-    public void D_deleteEventTest() {
+    public void D_test_deleteEvent() {
         onView(withId(R.id.view_all_habits)).perform(click());
         onView(withText(HabitTest.HABIT_TITLE)).perform(click());
         onView(withId(R.id.button_delete)).perform(click());

--- a/app/src/androidTest/java/com/github/cmput301f21t44/hellohabits/HabitTest.java
+++ b/app/src/androidTest/java/com/github/cmput301f21t44/hellohabits/HabitTest.java
@@ -52,7 +52,7 @@ public class HabitTest {
     }
 
     @Test
-    public void A_addHabitTest() {
+    public void A_test_addHabit() {
         onView(withId(R.id.button_new_habit)).perform(click());
         onView(withId(R.id.edit_text_title)).perform(typeText(HABIT_TITLE), closeSoftKeyboard());
         onView(withId(R.id.edit_text_reason)).perform(typeText(HABIT_REASON), closeSoftKeyboard());
@@ -67,7 +67,7 @@ public class HabitTest {
     }
 
     @Test
-    public void B_viewHabitTest() {
+    public void B_test_viewHabit() {
         onView(withText(HABIT_TITLE)).perform(click());
 
         onView(withId(R.id.view_title)).check(matches(withText(HABIT_TITLE)));
@@ -78,7 +78,7 @@ public class HabitTest {
     }
 
     @Test
-    public void C_editHabitTest() {
+    public void C_test_editHabit() {
         onView(withText(HABIT_TITLE)).perform(click());
         onView(withId(R.id.button_edit_habit)).perform(click());
 
@@ -101,7 +101,7 @@ public class HabitTest {
     }
 
     @Test
-    public void D_deleteHabitTest() {
+    public void D_test_deleteHabit() {
         onView(withText(NEW_HABIT_TITLE)).perform(click());
 
         onView(withId(R.id.button_delete_habit)).perform(click());

--- a/app/src/androidTest/java/com/github/cmput301f21t44/hellohabits/LoginTest.java
+++ b/app/src/androidTest/java/com/github/cmput301f21t44/hellohabits/LoginTest.java
@@ -55,7 +55,7 @@ public class LoginTest {
     }
 
     @Test
-    public void A_testSignup() {
+    public void A_test_signup() {
         try {
             onView(withId(R.id.social)).perform(click());
         } catch (Exception ignored) {
@@ -69,7 +69,7 @@ public class LoginTest {
     }
 
     @Test
-    public void B_testLogin() {
+    public void B_test_login() {
         onView(withId(R.id.email)).perform(typeText(EMAIL), closeSoftKeyboard());
         onView(withId(R.id.password)).perform(typeText(PASSWORD), closeSoftKeyboard());
         onView(withId(R.id.submit)).perform(click());

--- a/app/src/test/java/com/github/cmput301f21t44/hellohabits/DaysOfWeekTest.java
+++ b/app/src/test/java/com/github/cmput301f21t44/hellohabits/DaysOfWeekTest.java
@@ -12,13 +12,13 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class DaysOfWeekTest {
     @Test
-    public void testToString_emptyArray() {
+    public void test_toString_emptyArray() {
         boolean[] daysOfWeek = DaysOfWeek.emptyArray();
         assertTrue(DaysOfWeek.toString(daysOfWeek).isEmpty());
     }
 
     @Test
-    public void testToString_oneDay() {
+    public void test_toString_oneDay() {
         for (int i = 0; i < DaysOfWeek.shorthandDays.length; ++i) {
             boolean[] daysOfWeek = DaysOfWeek.emptyArray();
             daysOfWeek[i] = true;
@@ -27,7 +27,7 @@ public class DaysOfWeekTest {
     }
 
     @Test
-    public void testToString_twoDays() {
+    public void test_toString_twoDays() {
         for (int i = 0; i < DaysOfWeek.shorthandDays.length - 1; ++i) {
             boolean[] daysOfWeek = DaysOfWeek.emptyArray();
             daysOfWeek[i] = true;

--- a/app/src/test/java/com/github/cmput301f21t44/hellohabits/HabitViewModelTest.java
+++ b/app/src/test/java/com/github/cmput301f21t44/hellohabits/HabitViewModelTest.java
@@ -1,0 +1,96 @@
+package com.github.cmput301f21t44.hellohabits;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
+import androidx.lifecycle.LiveData;
+
+import com.github.cmput301f21t44.hellohabits.firebase.FirebaseTask;
+import com.github.cmput301f21t44.hellohabits.model.DaysOfWeek;
+import com.github.cmput301f21t44.hellohabits.model.Habit;
+import com.github.cmput301f21t44.hellohabits.model.HabitRepository;
+import com.github.cmput301f21t44.hellohabits.viewmodel.HabitViewModel;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.Instant;
+import java.util.List;
+
+@RunWith(JUnit4.class)
+public class HabitViewModelTest {
+    @Rule
+    public InstantTaskExecutorRule instantTaskExecutorRule = new InstantTaskExecutorRule();
+
+    @Mock
+    HabitRepository habitRepository;
+
+    @Mock
+    LiveData<List<Habit>> mockHabits;
+
+    @Captor
+    ArgumentCaptor<String> nameCaptor;
+    @Captor
+    ArgumentCaptor<String> reasonCaptor;
+    @Captor
+    ArgumentCaptor<Instant> dateStartedCaptor;
+    @Captor
+    ArgumentCaptor<boolean[]> daysOfWeekCaptor;
+    @Captor
+    ArgumentCaptor<FirebaseTask.ThenFunction> successCallbackCaptor;
+    @Captor
+    ArgumentCaptor<FirebaseTask.CatchFunction> failCallbackCaptor;
+
+    private HabitViewModel viewModel;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        when(habitRepository.getAllHabits()).thenReturn(mockHabits);
+        viewModel = new HabitViewModel(habitRepository);
+    }
+
+    @Test
+    public void testGetHabits() {
+        assertEquals(mockHabits, viewModel.getAllHabits());
+    }
+
+    @Test
+    public void testInsert() {
+        // Initialize method parameters
+        String name = "Test Title";
+        String reason = "Test Reason";
+        Instant dateStarted = Instant.now();
+        boolean[] daysOfWeek = DaysOfWeek.emptyArray();
+        FirebaseTask.ThenFunction successCallback = () -> {
+        };
+        FirebaseTask.CatchFunction failCallback = (e) -> {
+        };
+
+        // Call method to test
+        viewModel.insert(name, reason, dateStarted, daysOfWeek, successCallback, failCallback);
+
+        // Capture values passed to the mock object
+        verify(habitRepository, times(1)).insert(nameCaptor.capture(), reasonCaptor.capture(),
+                dateStartedCaptor.capture(), daysOfWeekCaptor.capture(),
+                successCallbackCaptor.capture(), failCallbackCaptor.capture());
+
+        // Verify that the mock method was called with the right parameters
+        assertEquals(name, nameCaptor.getValue());
+        assertEquals(reason, reasonCaptor.getValue());
+        assertEquals(dateStarted, dateStartedCaptor.getValue());
+        assertEquals(daysOfWeek, daysOfWeekCaptor.getValue());
+        assertEquals(successCallback, successCallbackCaptor.getValue());
+        assertEquals(failCallback, failCallbackCaptor.getValue());
+    }
+}

--- a/app/src/test/java/com/github/cmput301f21t44/hellohabits/HabitViewModelTest.java
+++ b/app/src/test/java/com/github/cmput301f21t44/hellohabits/HabitViewModelTest.java
@@ -32,12 +32,21 @@ public class HabitViewModelTest {
     @Rule
     public InstantTaskExecutorRule instantTaskExecutorRule = new InstantTaskExecutorRule();
 
+    /**
+     * Mock HabitRepository object to be injected to HabitViewModel
+     */
     @Mock
-    HabitRepository habitRepository;
+    HabitRepository mockHabitRepo;
 
+    /**
+     * LiveData stub to be returned by HabitRepository.getAllHabits
+     */
     @Mock
-    LiveData<List<Habit>> mockHabits;
+    LiveData<List<Habit>> habitListStub;
 
+    /**
+     * Argument captors
+     */
     @Captor
     ArgumentCaptor<String> nameCaptor;
     @Captor
@@ -51,22 +60,27 @@ public class HabitViewModelTest {
     @Captor
     ArgumentCaptor<FirebaseTask.CatchFunction> failCallbackCaptor;
 
+    /**
+     * HabitViewModel, the class being tested
+     */
     private HabitViewModel viewModel;
 
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
-        when(habitRepository.getAllHabits()).thenReturn(mockHabits);
-        viewModel = new HabitViewModel(habitRepository);
+        // Provide stub value for getAllHabits
+        when(mockHabitRepo.getAllHabits()).thenReturn(habitListStub);
+        viewModel = new HabitViewModel(mockHabitRepo);
     }
 
     @Test
-    public void testGetHabits() {
-        assertEquals(mockHabits, viewModel.getAllHabits());
+    public void test_getAllHabits() {
+        // Verify that getAllHabits returns the stub
+        assertEquals(habitListStub, viewModel.getAllHabits());
     }
 
     @Test
-    public void testInsert() {
+    public void test_insert() {
         // Initialize method parameters
         String name = "Test Title";
         String reason = "Test Reason";
@@ -81,7 +95,7 @@ public class HabitViewModelTest {
         viewModel.insert(name, reason, dateStarted, daysOfWeek, successCallback, failCallback);
 
         // Capture values passed to the mock object
-        verify(habitRepository, times(1)).insert(nameCaptor.capture(), reasonCaptor.capture(),
+        verify(mockHabitRepo, times(1)).insert(nameCaptor.capture(), reasonCaptor.capture(),
                 dateStartedCaptor.capture(), daysOfWeekCaptor.capture(),
                 successCallbackCaptor.capture(), failCallbackCaptor.capture());
 


### PR DESCRIPTION
Provided an example on how to test the ViewModel classes. Dependency injection makes unit testing straightforward.

In this example, `HabitViewModel` only depends on one other class, which is the `HabitRepository`. We only need to verify that:

1. `HabitViewModel`'s methods call the right methods from `HabitRepository`
2. It passes the right inputs to the method

We first create variables for the parameters since we'll need references
to them to verify the called method.
We then call the method that we need to test with the created parameters. In this case, it's `HabitViewModel.insert` method.
Then, we verify that the mock `HabitRepository.insert` method that the `HabitViewModel.insert` is supposed to call was indeed called, along with the right parameters. This is done by capturing the method parameters with `ArgumentCaptor`s.

Testing the MutableLiveData `mSelectedHabit` might be a bit more complicated, but the rest should follow the same pattern as the `testInsert` case.

Summary:

1. Call method to test with example parameters
2. Verify the number of invocations and capture the values passed to the mock using Mockito's
`verify(MOCK_OBJECT, times(N_INVOCATIONS)).METHOD_BEING_TESTED(LIST_OF_CAPTORS)`
3. Compare the captor values to the passed parameters