### PR TITLE
Testing: View Models

### DIFF
--- a/app/src/test/java/com/github/cmput301f21t44/hellohabits/HabitEventViewModelTest.java
+++ b/app/src/test/java/com/github/cmput301f21t44/hellohabits/HabitEventViewModelTest.java
@@ -1,0 +1,161 @@
+package com.github.cmput301f21t44.hellohabits;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
+import androidx.lifecycle.LiveData;
+
+import com.github.cmput301f21t44.hellohabits.firebase.CatchFunction;
+import com.github.cmput301f21t44.hellohabits.firebase.ResultFunction;
+import com.github.cmput301f21t44.hellohabits.firebase.ThenFunction;
+import com.github.cmput301f21t44.hellohabits.model.habitevent.HabitEvent;
+import com.github.cmput301f21t44.hellohabits.model.habitevent.HabitEventRepository;
+import com.github.cmput301f21t44.hellohabits.viewmodel.HabitEventViewModel;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Test class for the HabitEventViewModel
+ * <p>
+ * Tests all methods of the HabitEventViewModel
+ */
+@RunWith(JUnit4.class)
+public class HabitEventViewModelTest {
+    // Initialize method parameters
+    private static final String id = "1944ce84-3b81-4763-9ff7-26aa48eb8f81";
+    private static final String habitId = "85c92132-3977-4b2e-84e5-f97298a69885";
+    private static final String comment = "Test Comment";
+    private static final Instant date = Instant.now();
+    private static final ThenFunction thenCallback = () -> {
+    };
+    private static final ResultFunction<HabitEvent> resultCallback = (h) -> {
+    };
+    private static final CatchFunction failCallback = (e) -> {
+    };
+
+    @Rule
+    public InstantTaskExecutorRule instantTaskExecutorRule = new InstantTaskExecutorRule();
+
+    /**
+     * Mock HabitEventRepository object to be injected to HabitEventViewModel
+     */
+    @Mock
+    HabitEventRepository mockHabitEventRepo;
+
+    @Mock
+    HabitEvent mockHabitEvent;
+
+    /**
+     * LiveData stub to be returned by HabitEventRepository.getEventsByHabitId
+     */
+    @Mock
+    LiveData<List<HabitEvent>> habitEventListStub;
+
+    /**
+     * Argument captors
+     */
+    @Captor
+    ArgumentCaptor<String> idCaptor;
+    @Captor
+    ArgumentCaptor<String> habitIdCaptor;
+    @Captor
+    ArgumentCaptor<String> commentCaptor;
+    @Captor
+    ArgumentCaptor<Instant> dateCaptor;
+    @Captor
+    ArgumentCaptor<ThenFunction> thenCallbackCaptor;
+    @Captor
+    ArgumentCaptor<ResultFunction<HabitEvent>> resultCallbackCaptor;
+    @Captor
+    ArgumentCaptor<CatchFunction> failCallbackCaptor;
+    @Captor
+    ArgumentCaptor<HabitEvent> habitEventCaptor;
+
+    /**
+     * HabitEventViewModel, the class being tested
+     */
+    private HabitEventViewModel viewModel;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        // Provide stub value for getAllHabits
+        when(mockHabitEventRepo.getEventsByHabitId(habitId)).thenReturn(habitEventListStub);
+        viewModel = new HabitEventViewModel(mockHabitEventRepo);
+    }
+
+    @Test
+    public void test_isDefined() {
+        assertNotNull(viewModel);
+    }
+
+    @Test
+    public void test_selectedEvent() {
+        viewModel.setSelectedEvent(mockHabitEvent);
+        assertEquals(mockHabitEvent, viewModel.getSelectedEvent().getValue());
+    }
+
+    @Test
+    public void test_getEventsByHabitId() {
+        assertEquals(habitEventListStub, viewModel.getHabitEventsById(habitId));
+    }
+
+    @Test
+    public void test_insert() {
+        // Call method to test
+        viewModel.insert(habitId, comment, thenCallback, failCallback);
+
+        // Capture values passed to the mock object
+        verify(mockHabitEventRepo, times(1)).insert(habitIdCaptor.capture(),
+                commentCaptor.capture(), thenCallbackCaptor.capture(),
+                failCallbackCaptor.capture());
+
+        // Verify that the mock method was called with the right parameters
+        assertEquals(habitId, habitIdCaptor.getValue());
+        assertEquals(comment, commentCaptor.getValue());
+        assertEquals(thenCallback, thenCallbackCaptor.getValue());
+        assertEquals(failCallback, failCallbackCaptor.getValue());
+    }
+
+    @Test
+    public void test_update() {
+        viewModel.update(id, habitId, date, comment, resultCallback, failCallback);
+
+        verify(mockHabitEventRepo, times(1)).update(idCaptor.capture(),
+                habitIdCaptor.capture(), dateCaptor.capture(), commentCaptor.capture(),
+                resultCallbackCaptor.capture(), failCallbackCaptor.capture());
+
+        assertEquals(id, idCaptor.getValue());
+        assertEquals(habitId, habitIdCaptor.getValue());
+        assertEquals(date, dateCaptor.getValue());
+        assertEquals(comment, commentCaptor.getValue());
+        assertEquals(resultCallback, resultCallbackCaptor.getValue());
+        assertEquals(failCallback, failCallbackCaptor.getValue());
+    }
+
+    @Test
+    public void test_delete() {
+        viewModel.delete(mockHabitEvent, failCallback);
+
+        verify(mockHabitEventRepo, times(1))
+                .delete(habitEventCaptor.capture(), failCallbackCaptor.capture());
+
+        assertEquals(mockHabitEvent, habitEventCaptor.getValue());
+        assertEquals(failCallback, failCallbackCaptor.getValue());
+    }
+}

--- a/app/src/test/java/com/github/cmput301f21t44/hellohabits/HabitViewModelTest.java
+++ b/app/src/test/java/com/github/cmput301f21t44/hellohabits/HabitViewModelTest.java
@@ -1,6 +1,8 @@
 package com.github.cmput301f21t44.hellohabits;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -9,10 +11,12 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
 import androidx.lifecycle.LiveData;
 
 import com.github.cmput301f21t44.hellohabits.firebase.CatchFunction;
+import com.github.cmput301f21t44.hellohabits.firebase.ResultFunction;
 import com.github.cmput301f21t44.hellohabits.firebase.ThenFunction;
 import com.github.cmput301f21t44.hellohabits.model.habit.DaysOfWeek;
 import com.github.cmput301f21t44.hellohabits.model.habit.Habit;
 import com.github.cmput301f21t44.hellohabits.model.habit.HabitRepository;
+import com.github.cmput301f21t44.hellohabits.view.habit.HabitIndexChange;
 import com.github.cmput301f21t44.hellohabits.viewmodel.HabitViewModel;
 
 import org.junit.Before;
@@ -28,8 +32,28 @@ import org.mockito.MockitoAnnotations;
 import java.time.Instant;
 import java.util.List;
 
+/**
+ * Test class for the HabitViewModel
+ * <p>
+ * Tests all methods of the HabitViewModel
+ */
 @RunWith(JUnit4.class)
 public class HabitViewModelTest {
+    // Initialize method parameters
+    private static final String id = "1944ce84-3b81-4763-9ff7-26aa48eb8f81";
+    private static final String name = "Test Title";
+    private static final String email = "test_user@example.com";
+    private static final String reason = "Test Reason";
+    private static final Instant dateStarted = Instant.now();
+    private static final boolean[] daysOfWeek = DaysOfWeek.emptyArray();
+    private static final int index = 1;
+    private static final ThenFunction thenCallback = () -> {
+    };
+    private static final ResultFunction<Habit> resultCallback = (h) -> {
+    };
+    private static final CatchFunction failCallback = (e) -> {
+    };
+
     @Rule
     public InstantTaskExecutorRule instantTaskExecutorRule = new InstantTaskExecutorRule();
 
@@ -38,6 +62,12 @@ public class HabitViewModelTest {
      */
     @Mock
     HabitRepository mockHabitRepo;
+
+    @Mock
+    Habit mockHabit;
+
+    @Mock
+    List<HabitIndexChange> mockChangeList;
 
     /**
      * LiveData stub to be returned by HabitRepository.getAllHabits
@@ -49,6 +79,8 @@ public class HabitViewModelTest {
      * Argument captors
      */
     @Captor
+    ArgumentCaptor<String> idCaptor;
+    @Captor
     ArgumentCaptor<String> nameCaptor;
     @Captor
     ArgumentCaptor<String> reasonCaptor;
@@ -59,9 +91,17 @@ public class HabitViewModelTest {
     @Captor
     ArgumentCaptor<Boolean> isPrivateCaptor;
     @Captor
-    ArgumentCaptor<ThenFunction> successCallbackCaptor;
+    ArgumentCaptor<Integer> indexCaptor;
+    @Captor
+    ArgumentCaptor<ThenFunction> thenCallbackCaptor;
+    @Captor
+    ArgumentCaptor<ResultFunction<Habit>> resultCallbackCaptor;
     @Captor
     ArgumentCaptor<CatchFunction> failCallbackCaptor;
+    @Captor
+    ArgumentCaptor<Habit> habitCaptor;
+    @Captor
+    ArgumentCaptor<List<HabitIndexChange>> changeListCaptor;
 
     /**
      * HabitViewModel, the class being tested
@@ -73,7 +113,26 @@ public class HabitViewModelTest {
         MockitoAnnotations.initMocks(this);
         // Provide stub value for getAllHabits
         when(mockHabitRepo.getAllHabits()).thenReturn(habitListStub);
+        when(mockHabitRepo.getUserPublicHabits(email)).thenReturn(habitListStub);
         viewModel = new HabitViewModel(mockHabitRepo);
+    }
+
+    @Test
+    public void test_isDefined() {
+        assertNotNull(viewModel);
+    }
+
+    @Test
+    public void test_selectedHabit() {
+        viewModel.setSelectedHabit(mockHabit);
+        assertEquals(mockHabit, viewModel.getSelectedHabit().getValue());
+    }
+
+    @Test
+    public void test_reordering() {
+        viewModel.setReordering(true);
+        //noinspection ConstantConditions
+        assertTrue(viewModel.getReordering().getValue());
     }
 
     @Test
@@ -83,25 +142,21 @@ public class HabitViewModelTest {
     }
 
     @Test
-    public void test_insert() {
-        // Initialize method parameters
-        String name = "Test Title";
-        String reason = "Test Reason";
-        Instant dateStarted = Instant.now();
-        boolean[] daysOfWeek = DaysOfWeek.emptyArray();
-        ThenFunction successCallback = () -> {
-        };
-        CatchFunction failCallback = (e) -> {
-        };
+    public void test_getUserPublicHabits() {
+        assertEquals(habitListStub, viewModel.getUserPublicHabits(email));
+    }
 
+    @Test
+    public void test_insert() {
         // Call method to test
-        viewModel.insert(name, reason, dateStarted, daysOfWeek, true, successCallback,
+        viewModel.insert(name, reason, dateStarted, daysOfWeek, true, thenCallback,
                 failCallback);
 
         // Capture values passed to the mock object
-        verify(mockHabitRepo, times(1)).insert(nameCaptor.capture(), reasonCaptor.capture(),
-                dateStartedCaptor.capture(), daysOfWeekCaptor.capture(), isPrivateCaptor.capture(),
-                successCallbackCaptor.capture(), failCallbackCaptor.capture());
+        verify(mockHabitRepo, times(1)).insert(nameCaptor.capture(),
+                reasonCaptor.capture(), dateStartedCaptor.capture(), daysOfWeekCaptor.capture(),
+                isPrivateCaptor.capture(), thenCallbackCaptor.capture(),
+                failCallbackCaptor.capture());
 
         // Verify that the mock method was called with the right parameters
         assertEquals(name, nameCaptor.getValue());
@@ -109,7 +164,51 @@ public class HabitViewModelTest {
         assertEquals(dateStarted, dateStartedCaptor.getValue());
         assertEquals(daysOfWeek, daysOfWeekCaptor.getValue());
         assertEquals(true, isPrivateCaptor.getValue());
-        assertEquals(successCallback, successCallbackCaptor.getValue());
+        assertEquals(thenCallback, thenCallbackCaptor.getValue());
+        assertEquals(failCallback, failCallbackCaptor.getValue());
+    }
+
+    @Test
+    public void test_update() {
+        viewModel.update(id, name, reason, dateStarted, daysOfWeek, true, index,
+                resultCallback, failCallback);
+
+        verify(mockHabitRepo, times(1)).update(idCaptor.capture(),
+                nameCaptor.capture(), reasonCaptor.capture(), dateStartedCaptor.capture(),
+                daysOfWeekCaptor.capture(), isPrivateCaptor.capture(), indexCaptor.capture(),
+                resultCallbackCaptor.capture(), failCallbackCaptor.capture());
+
+        assertEquals(id, idCaptor.getValue());
+        assertEquals(name, nameCaptor.getValue());
+        assertEquals(reason, reasonCaptor.getValue());
+        assertEquals(dateStarted, dateStartedCaptor.getValue());
+        assertEquals(daysOfWeek, daysOfWeekCaptor.getValue());
+        assertEquals(true, isPrivateCaptor.getValue());
+        assertEquals(index, (int) indexCaptor.getValue());
+        assertEquals(resultCallback, resultCallbackCaptor.getValue());
+        assertEquals(failCallback, failCallbackCaptor.getValue());
+    }
+
+    @Test
+    public void test_delete() {
+        viewModel.delete(mockHabit, thenCallback, failCallback);
+
+        verify(mockHabitRepo, times(1)).delete(habitCaptor.capture(),
+                thenCallbackCaptor.capture(), failCallbackCaptor.capture());
+
+        assertEquals(mockHabit, habitCaptor.getValue());
+        assertEquals(thenCallback, thenCallbackCaptor.getValue());
+        assertEquals(failCallback, failCallbackCaptor.getValue());
+    }
+
+    @Test
+    public void test_updateIndices() {
+        viewModel.updateIndices(mockChangeList, failCallback);
+
+        verify(mockHabitRepo, times(1))
+                .updateIndices(changeListCaptor.capture(), failCallbackCaptor.capture());
+
+        assertEquals(mockChangeList, changeListCaptor.getValue());
         assertEquals(failCallback, failCallbackCaptor.getValue());
     }
 }

--- a/app/src/test/java/com/github/cmput301f21t44/hellohabits/PreviousListViewModelTest.java
+++ b/app/src/test/java/com/github/cmput301f21t44/hellohabits/PreviousListViewModelTest.java
@@ -1,7 +1,9 @@
 package com.github.cmput301f21t44.hellohabits;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
 
@@ -30,6 +32,8 @@ public class PreviousListViewModelTest {
         assertNotNull(previousListViewModel);
         //noinspection ConstantConditions
         assertEquals(R.id.TodaysHabitsFragment, (long) previousListViewModel.getDestinationId().getValue());
+        //noinspection ConstantConditions
+        assertFalse(previousListViewModel.getFromViewHabit().getValue());
     }
 
     @Test
@@ -38,5 +42,12 @@ public class PreviousListViewModelTest {
         previousListViewModel.setDestinationId(id);
         //noinspection ConstantConditions
         assertEquals(id, (long) previousListViewModel.getDestinationId().getValue());
+    }
+
+    @Test
+    public void test_fromViewHabit() {
+        previousListViewModel.setFromViewHabit(true);
+        //noinspection ConstantConditions
+        assertTrue(previousListViewModel.getFromViewHabit().getValue());
     }
 }

--- a/app/src/test/java/com/github/cmput301f21t44/hellohabits/UserViewModelTest.java
+++ b/app/src/test/java/com/github/cmput301f21t44/hellohabits/UserViewModelTest.java
@@ -1,0 +1,158 @@
+package com.github.cmput301f21t44.hellohabits;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
+import androidx.lifecycle.LiveData;
+
+import com.github.cmput301f21t44.hellohabits.firebase.CatchFunction;
+import com.github.cmput301f21t44.hellohabits.firebase.ThenFunction;
+import com.github.cmput301f21t44.hellohabits.model.habitevent.HabitEvent;
+import com.github.cmput301f21t44.hellohabits.model.social.User;
+import com.github.cmput301f21t44.hellohabits.model.social.UserRepository;
+import com.github.cmput301f21t44.hellohabits.viewmodel.UserViewModel;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+
+/**
+ * Test class for the UserViewModel
+ * <p>
+ * Tests all methods of the UserViewModel except for the getters for MediatorLiveData members
+ * as that is part of implementation (or bad design :P)
+ */
+@RunWith(JUnit4.class)
+public class UserViewModelTest {
+    // Initialize method parameters
+    private static final String email = "test_user@example.com";
+    private static final ThenFunction thenCallback = () -> {
+    };
+    private static final CatchFunction failCallback = (e) -> {
+    };
+
+    @Rule
+    public InstantTaskExecutorRule instantTaskExecutorRule = new InstantTaskExecutorRule();
+
+    /**
+     * Mock UserRepository object to be injected to UserViewModel
+     */
+    @Mock
+    UserRepository mockUserRepo;
+
+    @Mock
+    User mockUser;
+
+    /**
+     * LiveData stub to be returned by UserRepository.getAllUsers
+     */
+    @Mock
+    LiveData<List<User>> userListStub;
+
+    /**
+     * Argument captors
+     */
+    @Captor
+    ArgumentCaptor<String> emailCaptor;
+    @Captor
+    ArgumentCaptor<ThenFunction> thenCallbackCaptor;
+    @Captor
+    ArgumentCaptor<CatchFunction> failCallbackCaptor;
+    @Captor
+    ArgumentCaptor<HabitEvent> habitEventCaptor;
+
+    /**
+     * UserViewModel, the class being tested
+     */
+    private UserViewModel viewModel;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        // Provide stub value for getAllHabits
+        when(mockUserRepo.getAllUsers()).thenReturn(userListStub);
+        viewModel = new UserViewModel(mockUserRepo);
+    }
+
+    @Test
+    public void test_isDefined() {
+        assertNotNull(viewModel);
+    }
+
+    @Test
+    public void test_selectedUser() {
+        viewModel.setSelectedUser(mockUser);
+        assertEquals(mockUser, viewModel.getSelectedUser().getValue());
+    }
+
+    @Test
+    public void test_getAllUsers() {
+        assertEquals(userListStub, viewModel.getAllUsers());
+    }
+
+    @Test
+    public void test_requestFollow() {
+        // Call method to test
+        viewModel.requestFollow(email, thenCallback, failCallback);
+
+        // Capture values passed to the mock object
+        verify(mockUserRepo, times(1)).requestFollow(emailCaptor.capture(),
+                thenCallbackCaptor.capture(), failCallbackCaptor.capture());
+
+        // Verify that the mock method was called with the right parameters
+        assertEquals(email, emailCaptor.getValue());
+        assertEquals(thenCallback, thenCallbackCaptor.getValue());
+        assertEquals(failCallback, failCallbackCaptor.getValue());
+    }
+
+    @Test
+    public void test_cancelFollowRequest() {
+        // Call method to test
+        viewModel.cancelFollowRequest(email, thenCallback, failCallback);
+
+        // Capture values passed to the mock object
+        verify(mockUserRepo, times(1)).cancelFollow(emailCaptor.capture(),
+                thenCallbackCaptor.capture(), failCallbackCaptor.capture());
+
+        // Verify that the mock method was called with the right parameters
+        assertEquals(email, emailCaptor.getValue());
+        assertEquals(thenCallback, thenCallbackCaptor.getValue());
+        assertEquals(failCallback, failCallbackCaptor.getValue());
+    }
+
+    @Test
+    public void test_acceptFollow() {
+        viewModel.acceptFollow(email, thenCallback, failCallback);
+
+        verify(mockUserRepo, times(1)).acceptFollow(emailCaptor.capture(),
+                thenCallbackCaptor.capture(), failCallbackCaptor.capture());
+
+        assertEquals(email, emailCaptor.getValue());
+        assertEquals(thenCallback, thenCallbackCaptor.getValue());
+        assertEquals(failCallback, failCallbackCaptor.getValue());
+    }
+
+    @Test
+    public void test_rejectFollow() {
+        viewModel.rejectFollow(email, thenCallback, failCallback);
+
+        verify(mockUserRepo, times(1)).rejectFollow(emailCaptor.capture(),
+                thenCallbackCaptor.capture(), failCallbackCaptor.capture());
+
+        assertEquals(email, emailCaptor.getValue());
+        assertEquals(thenCallback, thenCallbackCaptor.getValue());
+        assertEquals(failCallback, failCallbackCaptor.getValue());
+    }
+}


### PR DESCRIPTION
Added tests for `ViewModel`s made easy with dependency injection. We're not testing the `MediatorLiveData`s, though.

Closes #47 and closes #49. Not gonna open a new issue for the other view models just to close them immediately.