### PR TITLE
Remove lock from habit item by default

### DIFF
--- a/app/src/main/java/com/github/cmput301f21t44/hellohabits/view/MainActivity.java
+++ b/app/src/main/java/com/github/cmput301f21t44/hellohabits/view/MainActivity.java
@@ -122,5 +122,6 @@ public class MainActivity extends AppCompatActivity {
         Intent intent = new Intent(this, MainActivity.class);
         intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
         startActivity(intent);
+        finish();
     }
 }

--- a/app/src/main/java/com/github/cmput301f21t44/hellohabits/view/habit/HabitAdapter.java
+++ b/app/src/main/java/com/github/cmput301f21t44/hellohabits/view/habit/HabitAdapter.java
@@ -99,8 +99,8 @@ public class HabitAdapter extends ListAdapter<Habit, HabitAdapter.ViewHolder> {
         // change lock icon depending on the reordering state
         mViewModel.getReordering().observe(mLifeCycleOwner, isReordering -> {
             ImageView handle = holder.mItemBinding.lock;
+            handle.setVisibility(isReordering || current.isPrivate() ? VISIBLE : INVISIBLE);
             if (isReordering) {
-                handle.setVisibility(VISIBLE);
                 handle.setOnTouchListener((v, event) -> {
                     if (event.getActionMasked() == MotionEvent.ACTION_DOWN) {
                         mDragStartListener.onStartDrag(holder);
@@ -111,7 +111,6 @@ public class HabitAdapter extends ListAdapter<Habit, HabitAdapter.ViewHolder> {
             } else {
                 handle.setOnTouchListener(null);
                 handle.setImageResource(R.drawable.ic_baseline_lock_24);
-                handle.setVisibility(current.isPrivate() ? VISIBLE : INVISIBLE);
             }
         });
 
@@ -185,6 +184,7 @@ public class HabitAdapter extends ListAdapter<Habit, HabitAdapter.ViewHolder> {
         void bind(@NonNull final Habit habit, final OnItemClickListener<Habit> listener) {
             mItemBinding.titleView.setText(habit.getTitle());
             mItemBinding.reasonView.setText(habit.getReason());
+            mItemBinding.lock.setVisibility(INVISIBLE);
             // check level of consistency
             double consistency = Habit.getConsistency(habit);
 


### PR DESCRIPTION
Only make the lock view visible when reordering or if it's private

Also attempt to fix signout issue by adding finish() to the MainActivity
but that didn't work and I still get the SIGSEGV faults.
